### PR TITLE
NPM build error issue fix update

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@carbon/charts-react": "^1.13.30",
-    "@carbon/ibm-products": "^2.17.1",
+    "@carbon/ibm-products": "^2.21.0",
     "@carbon/react": "^1.39.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,7 +5,7 @@ import './index.scss';
 import App from './App';
 import './translation/i18n'
 import reportWebVitals from './reportWebVitals';
-import { unstable_FeatureFlags as FeatureFlags } from '@carbon/ibm-products';
+import { preview__FeatureFlags as FeatureFlags } from '@carbon/ibm-products';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
Description
@carbon/ibm-products package version using no longer exports unstable_FeatureFlags.
That API was experimental and has been removed or renamed in newer versions of the Carbon IBM Products library.

So we've updated the package version and modified the code to resolve the build error.